### PR TITLE
HTML output: add 'id' attribute foreach event

### DIFF
--- a/cfp/planning.py
+++ b/cfp/planning.py
@@ -151,6 +151,7 @@ class Program:
                     if event.row != 0:
                         continue
                     options = ' rowspan="%d" bgcolor="%s"' % (event.rowcount, event.talk.category.color)
+                    options += ' id="%d"' % event.id
                     cellcontent = escape(str(event.talk)) + '<br><em>' + escape(event.talk.get_speakers_str()) + '</em>'
                     if self.staff:
                         tags = event.talk.staff_tags


### PR DESCRIPTION
HTML output: add `id` attribute foreach event.

For example, it can be used when creating links from the schedule to events full descriptions (current alternative is the use the title of the event).